### PR TITLE
Added validation to see if sitemap exists before attempting to remove

### DIFF
--- a/src/Console/SitemapCreator.php
+++ b/src/Console/SitemapCreator.php
@@ -121,7 +121,9 @@ class SitemapCreator extends Command
      */
     private function persistUrlsToSitemap(string $sitemap)
     {
-        unlink($this->sitemap_file_path);
+        if (file_exists($this->sitemap_file_path)) {
+            unlink($this->sitemap_file_path);
+        }
 
         file_put_contents($this->sitemap_file_path, $sitemap);
     }


### PR DESCRIPTION
The script attempted to remove a file, even if it may not exist. This results in an error on the first run.